### PR TITLE
[Fixed]: Removed bootstrap clashes with navbar class

### DIFF
--- a/views/home.ejs
+++ b/views/home.ejs
@@ -1,7 +1,4 @@
 <%- include('includes/header.ejs') %>
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-KK94CHFLLe+nY2dmCWGMq91rCGa5gtU4mk92HdvYe+M/SXH301p5ILy+dN9+nJOZ" crossorigin="anonymous">
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ENjdO4Dr2bkBIFxQpeoTz1HIcje39Wm4jDKdf19U8gI4ddQ3GYNS7NTKfAdVQSZe" crossorigin="anonymous"></script>
-  <link rel="stylesheet" href="css/style.css" />
 </head>
 <%- include('includes/navbar.ejs') %>
   <main>


### PR DESCRIPTION
# Description
1. There were different navbar on home and other pages, due to Bootstrap import clashes.
2. Cards Styling were clashing due to bootstrap.
Before:
![image](https://github.com/SurajPratap10/Imagine_AI/assets/85329574/eddf6df6-a7bb-4eaa-9f13-132651b54345)
After:
![image](https://github.com/SurajPratap10/Imagine_AI/assets/85329574/55d8c0c2-5e25-4022-8d4e-5f7a0ffc2686)


* Fixes: #194 *

## Screenshots

Before: Navigation bar is bigger in height, Dalle OpenAI and Login are not centered
![image](https://github.com/SurajPratap10/Imagine_AI/assets/85329574/e39740c5-8677-45d3-8d08-1715802b60ff)

After:
![image](https://github.com/SurajPratap10/Imagine_AI/assets/85329574/50425756-cbfd-4965-8326-f5d2e9065e26)

You can also Check for the testing deployment below:
https://imagine-6grpasviu-pranavsikarwal.vercel.app/

This could be merged on priority, so that no more clashes on home.ejs are faced. (Removing bootstrap which caused clashes)

## Checklist

<!-- Mark the completed tasks with [x] -->
- [x] Removed the Bootstrap clashes and it's imports.
- [x] Checked for the Deployment after changes were made
