### PR TITLE
Made footer dark

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -467,10 +467,8 @@ img {
 }
 
 footer {
-  height: 15vh;
   width: 100%;
   color: white;
-  margin-top: 5rem;
 }
 
 footer a {

--- a/views/includes/footer.ejs
+++ b/views/includes/footer.ejs
@@ -86,6 +86,8 @@ footer{
 	/* position: fixed; */
 	bottom: 0;
 	left: 0;
+  background-color: #262626;
+  padding-top: 2rem;
 }
 footer .content{
   max-width: 1350px;


### PR DESCRIPTION
A lot of changes were made to the footer so I didn't change it to the footer I had suggested previously. I just made its background dark so it looks distinct.
<img width="1076" alt="image" src="https://github.com/SurajPratap10/Imagine_AI/assets/98284331/ab826e2d-7051-4965-af7a-57c32c5f16b9">
Fixed the issue of extra spacing in other pages.
<img width="1075" alt="image" src="https://github.com/SurajPratap10/Imagine_AI/assets/98284331/1cb8cae6-5990-4665-bb7d-7c70714b7b10">
We can now customize some background for log in and other pages.
There is a small form spacing issue in Image generation i guess as in mobile view it looks like this :
<img width="439" alt="image" src="https://github.com/SurajPratap10/Imagine_AI/assets/98284331/20cbfd26-232e-4608-91f0-eaa5aaa1015d">
And normally like this : 
<img width="1074" alt="image" src="https://github.com/SurajPratap10/Imagine_AI/assets/98284331/79240dca-94d5-43f3-8443-8e5a8a8142f2">
I didn't make any changes to the form styling.
So if these changes are suited, you can merge them under issue #225