### PR TITLE
🛠️ [FIX]: IMPROPER ALIGNMENT & REMOVED INLINE STYLES FOR COPYRIGHT TEXT

### DIFF
--- a/views/includes/footer.ejs
+++ b/views/includes/footer.ejs
@@ -111,8 +111,8 @@
         </div>
     </div>
   <hr style="margin-top: 40px;">
-  <div class="bottom" style="padding: 40px 0 40px 0">
-    <p class="bot-l" style="text-align: center;">Copyright © 2020 <a href="#">Imagine-AI</a> | All rights reserved</p>
+  <div class="bottom">
+    <p class="bot-l">Copyright © 2020 <a href="#">Imagine-AI</a> | All rights reserved</p>
   </div>
   
 </footer>
@@ -304,9 +304,10 @@ footer .content .media-icons a{
 }
 footer .bottom{
   width: 100%;
-  text-align: center;
   color: #d9d9d9;
-  padding: 0 40px 5px 0;
+  padding: 40px 0 40px 0;
+  display: grid;
+  place-items: center;
 }
 footer .bottom a{
   color: #134D58;


### PR DESCRIPTION
# Description
- This PR is about centering the copyright section properly, but when i started to working i saw that the usage of inline-styles.
- In frontend we must want to avoid inline styles, because it's one of the good practices we want to follow.
- I added manual style rules in `style` and remove the inline-styles from the elements

## Fixes #465 


## Screenshots

![image](https://github.com/SurajPratap10/Imagine_AI/assets/92252895/585100fe-8abd-4614-87ba-7d09ec721d05)

## Checklist

<!-- Mark the completed tasks with [x] -->

- [x] Tests have been added or updated to cover the changes
- [x] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [x] All tests are passing
