### PR TITLE
Added Licenses section and badge in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -45,6 +45,12 @@ The IMAGINE - AI, which is built using the OpenAI API library DALL-E 2, aims to 
 8. **[`Postman`](https://learning.postman.com/docs/introduction/overview/)**
 9. **[`Git & GitHub`](https://docs.github.com/en/get-started/using-git/about-git)**
 
+
+# Licenses
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+Terms and conditions for use, reproduction and distribution are under the [MIT License](https://opensource.org/license/mit/).
+
 # How to **use**?
 
 Create a file named `.env`.


### PR DESCRIPTION
# Description
Added the Licenses section and the MIT license badge to the readme. It looks better now.

## Fixes #577 

## Screenshots
![abgs](https://github.com/SurajPratap10/Imagine_AI/assets/116020663/0b070c31-9554-47f2-958c-b07fde48c026)


## Checklist

<!-- Mark the completed tasks with [x] -->

- [x] Tests have been added or updated to cover the changes
- [x] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [x] All tests are passing
