### PR TITLE
Adjusted the height of the login and signup page

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -238,6 +238,8 @@ body {
   font-family: "Roboto", sans-serif;
   font-weight: bold;
   display: inline-block;
+  padding: 0;
+  line-height: 2rem;
 }
 
 .navbar a:hover,
@@ -281,11 +283,6 @@ body {
   .left-nav-links,
   .right-nav-links {
     display: block;
-  }
-
-  .AI {
-    padding: 0;
-    line-height: 2rem;
   }
 
   .hide-sm {
@@ -624,7 +621,6 @@ button,
 /* --------------- Showcase CSS --------------- */
 
 .showcase {
-  height: 100vh;
   width: 100%;
   background: var(--primary-color);
 }
@@ -666,12 +662,10 @@ button,
   letter-spacing: 1px;
   color: rgb(255, 255, 255);
   text-align: center;
-
-  line-height: 6px;
   outline: none;
   animation: animate 5s linear infinite;
   margin-bottom: 60px;
-  padding-top: 60px;
+  padding-top: 90px;
 }
 
 .showcase form {

--- a/views/signup.ejs
+++ b/views/signup.ejs
@@ -59,7 +59,7 @@
         </head>
       </head>
       <%- include('includes/navbar.ejs') %>
-        <section class="showcase" id="showcase" style="margin-bottom: 90px; height: 900px;">
+        <section class="showcase" id="showcase">
           <form id="image-form" action="index.html" style="margin-top: 30px;">
             <h1 class="AI">SIGN UP</h1>
             <div class="form-control">


### PR DESCRIPTION
# Description

Hey, @SurajPratap10 The buttons were fixed by someone else so I found another bug and fixed it. I have adjusted the height of the login and signup page. Previously the heading on these pages was not visible due to heard coded height of the forms. But now it is visible. Please review my pr and merge it. Thank you!

## Fixes #574 

<!-- Replace `issue_no` with the issue number which is fixed in this PR -->

## Screenshots

Before:-
![image](https://github.com/SurajPratap10/Imagine_AI/assets/100675296/a5731f71-b584-4a5a-8f39-82fd047a57fd)
![image](https://github.com/SurajPratap10/Imagine_AI/assets/100675296/e0e178ec-d538-43c7-92d4-66b483b4ff6b)

After:-
![image](https://github.com/SurajPratap10/Imagine_AI/assets/100675296/be675a21-295a-4779-a528-55d29448ebb8)
![image](https://github.com/SurajPratap10/Imagine_AI/assets/100675296/f1bc483b-ca10-4620-ab71-6e9f7759c57c)


## Checklist

<!-- Mark the completed tasks with [x] -->

- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [x] All tests are passing
