### PR TITLE
Navabar in imagineAI page

### DIFF
--- a/views/imagineAi.ejs
+++ b/views/imagineAi.ejs
@@ -2,6 +2,7 @@
 <%- include('includes/header.ejs') %>
 </head>
 <%- include('includes/navbar.ejs') %>
+<%- include('includes/sidebar.ejs') %>
 <%- include('alan.ejs') %>
 <main>
     <section class="showcase" id="showcase">

--- a/views/includes/sidebar.ejs
+++ b/views/includes/sidebar.ejs
@@ -31,7 +31,13 @@
     font-size: 40px;
     width: 50px;
     display: none;
-  }
+    }
+
+    .hamburger i{
+      padding: 5px 10px;
+    background-color: whitesmoke;
+     border-radius: 10px;
+    }
 
   @media (max-width:900px){
     .hamburger{


### PR DESCRIPTION
# Description
Added a side navbar on the ImagineAI page and change the hamburger style to make it visible on all pages.

## Fixes #633 
   closes #633 **[style Bug]: Navbar menu is hidden in Imagin-AI page for mobile size** 
 

## Output

https://github.com/SurajPratap10/Imagine_AI/assets/86224794/00bd6070-d406-4aba-8b81-85a42106ea6e



## Checklist

<!-- Mark the completed tasks with [x] -->

- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [ ] All tests are passing
