### PR TITLE
docs: replace tech stack words into attractive badges 📛 ✨ 

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@
   <img src="https://img.shields.io/github/repo-size/SurajPratap10/Imagine_AI?style=for-the-badge" />
   <img src="https://img.shields.io/github/issues/SurajPratap10/Imagine_AI?style=for-the-badge" />
     <img src="https://img.shields.io/github/issues-closed-raw/SurajPratap10/Imagine_AI?style=for-the-badge" />
-  <img src="https://img.shields.io/github/last-commit/SurajPratap10/Imagine_AI?style=for-the-badge" />
+    <img src="https://img.shields.io/github/last-commit/SurajPratap10/Imagine_AI?style=for-the-badge" />
     <img src="https://img.shields.io/github/issues-pr/SurajPratap10/Imagine_AI?style=for-the-badge" />
     <img src="https://img.shields.io/github/issues-pr-closed-raw/SurajPratap10/Imagine_AI?style=for-the-badge" />
     <img src="https://img.shields.io/github/forks/SurajPratap10/Imagine_AI?style=for-the-badge" />
@@ -35,19 +35,24 @@ The IMAGINE - AI, which is built using the OpenAI API library DALL-E 2, aims to 
 <p align="right"><a href="#top">Back to Top</a></p>
   
 # Technology Stack used:
-1. **[`Node JS`](https://nodejs.org/en/docs/guides)**
-2. **[`Express JS`](https://expressjs.com/en/guide/routing.html)**
-3. **[`Javascript`](https://developer.mozilla.org/en-US/docs/Learn/JavaScript)**
-4. **[`EJS`](https://ejs.co)**
-5. **[`HTML`](https://developer.mozilla.org/en-US/docs/Web/HTML)**
-6. **[`CSS`](https://developer.mozilla.org/en-US/docs/Web/CSS)**
-7. **[`OpenAI API`](https://platform.openai.com/docs/introduction)**
-8. **[`Postman`](https://learning.postman.com/docs/introduction/overview/)**
-9. **[`Git & GitHub`](https://docs.github.com/en/get-started/using-git/about-git)**
+
+<div align=center>
+
+[![Node Js](https://img.shields.io/badge/Node%20js-339933?style=for-the-badge&logo=nodedotjs&logoColor=white)](https://nodejs.org/en/docs/guides)
+[![Express JS](https://img.shields.io/badge/Express%20js-000000?style=for-the-badge&logo=express&logoColor=white)](https://expressjs.com/en/guide/routing.html)
+[![JavaScript](https://img.shields.io/badge/JavaScript-323330?style=for-the-badge&logo=javascript&logoColor=F7DF1E)](https://developer.mozilla.org/en-US/docs/Learn/JavaScript)
+[![EJS](https://img.shields.io/badge/EJS-A91E50?style=for-the-badge&logo=javascript&logoColor=white)](https://ejs.co)
+[![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)](https://developer.mozilla.org/en-US/docs/Web/HTML)
+[![CSS](https://img.shields.io/badge/CSS3-1572B6?style=for-the-badge&logo=css3&logoColor=white)](https://developer.mozilla.org/en-US/docs/Web/CSS)
+[![OpenAI API](https://img.shields.io/badge/OpenAI%20API-75A99C?style=for-the-badge&logo=openai&logoColor=white)](https://platform.openai.com/docs/introduction)
+[![Postman](https://img.shields.io/badge/Postman-FF6C37?style=for-the-badge&logo=Postman&logoColor=white)](https://learning.postman.com/docs/introduction/overview/)
+[![Git](https://img.shields.io/badge/GIT-E44C30?style=for-the-badge&logo=git&logoColor=white)](https://docs.github.com/en/get-started/using-git/about-git)
+
+</div>
 
 # Licenses
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=for-the-badge)](https://opensource.org/licenses/MIT)
 
 Terms and conditions for use, reproduction and distribution are under the [MIT License](https://opensource.org/license/mit/).
 

--- a/readme.md
+++ b/readme.md
@@ -43,6 +43,7 @@ The IMAGINE - AI, which is built using the OpenAI API library DALL-E 2, aims to 
 [![JavaScript](https://img.shields.io/badge/JavaScript-323330?style=for-the-badge&logo=javascript&logoColor=F7DF1E)](https://developer.mozilla.org/en-US/docs/Learn/JavaScript)
 [![EJS](https://img.shields.io/badge/EJS-A91E50?style=for-the-badge&logo=javascript&logoColor=white)](https://ejs.co)
 [![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)](https://developer.mozilla.org/en-US/docs/Web/HTML)
+
 [![CSS](https://img.shields.io/badge/CSS3-1572B6?style=for-the-badge&logo=css3&logoColor=white)](https://developer.mozilla.org/en-US/docs/Web/CSS)
 [![OpenAI API](https://img.shields.io/badge/OpenAI%20API-75A99C?style=for-the-badge&logo=openai&logoColor=white)](https://platform.openai.com/docs/introduction)
 [![Postman](https://img.shields.io/badge/Postman-FF6C37?style=for-the-badge&logo=Postman&logoColor=white)](https://learning.postman.com/docs/introduction/overview/)


### PR DESCRIPTION
# Description
- Improve readability of Imagine AI Documentation by replacing plain text based tech stack into attractive badges with links
- The user can navigate to the corresponding stack by clicking the image.

## Fixes #774 

## Screenshots

|||
|:---:|:---:|
|**BEFORE**|![image](https://user-images.githubusercontent.com/92252895/258851189-8a5f6331-64a1-4fa8-80bd-a6f4cf05ed48.png)|
|**AFTER**|![image](https://github.com/SurajPratap10/Imagine_AI/assets/92252895/3d35237b-fa49-4b21-8259-c7945a7a5434)|

## Checklist

<!-- Mark the completed tasks with [x] -->

- [x] Tests have been added or updated to cover the changes
- [x] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [x] All tests are passing
