### PR TITLE
docs: made gssoc banner adaptive to github light/dark mode 🌞/🌚 ✨  

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 <div align="center" id="top">
   
 <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="./public/imagine-ai-low-resolution-logo-color-on-transparent-background.png">
+    <source media="(prefers-color-scheme: light)" srcset="./public/imagine-ai-low-resolution-logo-color-on-transparent-background.png">
     <source media="(prefers-color-scheme: dark)" srcset="./public/imagine-ai-low-resolution-logo-color-on-transparent-background-dark.png">
     <img alt="Imagine AI" width=350 src="./public/imagine-ai-low-resolution-logo-color-on-transparent-background-dark.png">
 </picture>
@@ -190,11 +190,25 @@ git push -u origin <your_branch_name>
 
 # Open Source Events
 
-- GSSoC'23
+<div align="center">
 
-<p align="center"> 
-<img src= https://github.com/SurajPratap10/Imagine_AI/assets/92919173/3f546e37-be43-4884-88c1-a87eeeaeb92c />
-</p>
+  <picture>
+    <source 
+	    media="(prefers-color-scheme: dark)" 
+	    srcset="https://user-images.githubusercontent.com/63473496/213306279-338f7ce9-9a9f-4427-8c2a-3e344874498f.png"
+    >
+    <source 
+	    media="(prefers-color-scheme: light)" 
+	    srcset="https://raw.githubusercontent.com/GirlScriptSummerOfCode/MentorshipProgram/master/GSsoc%20Type%20Logo%20Black.png"
+    >
+    <img 
+	    alt="Girlscript Summer of Code" 
+	    width=80% 
+	    src="https://user-images.githubusercontent.com/63473496/213306279-338f7ce9-9a9f-4427-8c2a-3e344874498f.png"
+    >
+  </picture>
+
+</div>
 
 # Thanks to all Contributors 💪
 


### PR DESCRIPTION
# Description
- Made GSSOC Banner responsive to light/dark github mode, enhances the readability of Imagine AI Documentation.

## Fixes #753 

## Screenshots

|        BEFORE - LIGHT MODE       |        BEFORE - DARK MODE      |
| :------------------: | :------------------: |
| ![Image](https://user-images.githubusercontent.com/92252895/258637226-e2cc4f0b-7de3-4624-ac30-2788ec1ee5f4.png) | ![Image](https://user-images.githubusercontent.com/92252895/258637150-0fd9cce1-c4dd-4e87-b64f-b19dcd1795ed.png) |

<br>

|        AFTER - LIGHT MODE       |        AFTER - DARK MODE      |
| :------------------: | :------------------: |
|![image](https://github.com/SurajPratap10/Imagine_AI/assets/92252895/747d3a5d-d093-46bb-806f-32feafed3e64) | ![image](https://github.com/SurajPratap10/Imagine_AI/assets/92252895/ff5429e7-ac49-460c-b42f-148d2ee3c45a) | 


## Checklist

<!--
  Mark the completed tasks with [x]
-->

- [x] Tests have been added or updated to cover the changes
- [x] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [x] All tests are passing
