### PR TITLE
Fixed the z-index issue of Hamberger Menu

### DIFF
--- a/views/home.ejs
+++ b/views/home.ejs
@@ -75,7 +75,7 @@
             </div>
             <div style="display: flex; flex-direction: column; align-items: center; width: 100vw; height: 100vh; margin-top: 100px;">
               <h1 style="text-align: center; color: rgb(243, 243, 243); font-size: 3rem; margin-bottom: 20px;">TUTORIAL</h1>
-              <div style="display:flex; align-items: center;   width:fit-content;height:fit-content;">
+              <div style="display:flex; align-items: center;   width:90%;height:fit-content;">
         
                 <iframe allow="autoplay;" allowfullscreen style="border:none" src="https://clipchamp.com/watch/S9VfyxjttlP/embed" width="940" height="560"></iframe>
             </div>

--- a/views/includes/sidebar.ejs
+++ b/views/includes/sidebar.ejs
@@ -30,6 +30,7 @@
     font-size: 40px;
     width: 50px;
     display: none;
+    z-index: 9999;
     }
 
     .hamburger i{


### PR DESCRIPTION
# Description

I have fixed the issue related to the hamberger menu's positioning on mobile devices by adjusting the z-index to prevent other elements, like images, from overlapping with the menu. This is my first fix, and I will continue working on additional improvements for other related issues.

## Fixes #1113 