### PR TITLE
Fix: Sidebar Collapse via Hamburger Menu on Smaller Screens

### DIFF
--- a/views/includes/sidebar.ejs
+++ b/views/includes/sidebar.ejs
@@ -2,7 +2,7 @@
     <i class="bi bi-list"></i>
   </div>
   <div class="sidebar">
-   <div class="crossicon" onclick="sidbarinvissible()">x</div>
+   <div class="crossicon">x</div>
    <div class="content">
     <a class="white-color hover-effect <%= path === '/' ? 'active' : '' %>" href="/">HOME</a>
           <a class="white-color hover-effect <%= path === '/generateImg' ? 'active' : '' %>"
@@ -98,13 +98,18 @@ const hamburgere1=document.querySelector(".hamburger");
   const sidebarE1=document.querySelector(".sidebar");
   function sidebartoggle(){
     // hamburgere1.style.setProperty('display', 'none');
-    sidebarE1.style.setProperty('transform', 'translateX(0)');
+    if(sidebarE1.style.transform==='translateX(100%)'){
+      sidebarE1.style.setProperty('transform', 'translateX(0)');
+    }
+    else{
+      sidebarE1.style.setProperty('transform', 'translateX(100%)');
+    }
   }
 
-  function sidbarinvissible(){
-    // hamburgere1.style.setProperty('display', 'block');
+  // function sidbarinvissible(){
+  //   // hamburgere1.style.setProperty('display', 'block');
     
-    sidebarE1.style.setProperty('transform', 'translateX(100%)');
+  //   sidebarE1.style.setProperty('transform', 'translateX(100%)');
 
-  }
+  // }
   </script>


### PR DESCRIPTION
This pull request addresses the issue of the sidebar not collapsing when clicking the Hamburger Menu again on smaller screens.

- Fixed the issue where the sidebar did not close when clicking the Hamburger Menu for the second time.

### Fixes:

- Fixes issue #1126 

### Screenshots

|        BEFORE        |        AFTER         |
| :------------------: | :------------------: |
| <img width="1280" alt="Screenshot 2024-10-03 at 7 26 56 PM" src="https://github.com/user-attachments/assets/8add92f1-f015-4ada-9e1c-9f64b461aefa"> | <img width="1280" alt="Screenshot 2024-10-03 at 7 27 06 PM" src="https://github.com/user-attachments/assets/7784d279-3008-440c-a752-bf782570caf8"> |

### Checklist

- [x] Fixed the sidebar not collapsing on second click of the Hamburger Menu.