### PR TITLE
Fix: Adjust Social Media Icon Size on Login Page for All Screen Sizes

### DIFF
--- a/views/login.ejs
+++ b/views/login.ejs
@@ -9,6 +9,8 @@
             .signin-opt-icons a:hover img {
     transform: scale(1.1);
     transition: transform 0.3s ease-in-out;
+    width: 14rem;
+
 
           .google-icon {
             vertical-align: middle;
@@ -109,7 +111,7 @@
         <a href="/auth/google" class="google-button tooltip" aria-label="sign in with google">
           <img
             src="https://cdn-icons-png.flaticon.com/512/300/300221.png"
-            width="45px"
+            
           />
         </a>
 
@@ -118,7 +120,7 @@
           <!-- Please do the OAuth for facebook here, after completion, delete this comment -->
           <img
             src="https://cdn-icons-png.flaticon.com/512/733/733547.png"
-            width="45px"
+            
           />
         </a>
 
@@ -128,7 +130,7 @@
           <!-- Please do the OAuth for twitter here, after completion, delete this comment -->
           <img
             src="https://cdn-icons-png.flaticon.com/512/3256/3256013.png"
-            width="45px"
+            
           />
         </a>
       </div>


### PR DESCRIPTION
This pull request addresses the issue with the social media icons on the login page. The icons have been resized to ensure they are properly visible and balanced across all screen sizes, improving the user experience and design consistency.

### Fixes:

- Fixes issue #1130

### Changes Made:

- Increased the size of the social media icons for better visibility.
- Ensured responsive resizing for small to large screens to maintain consistency across devices.
- Adjusted alignment and spacing for a cleaner, more polished look.

### Screenshots:

|        BEFORE        |        AFTER         |
| :------------------: | :------------------: |
| <img width="1280" alt="Screenshot 2024-10-03 at 8 04 13 PM" src="https://github.com/user-attachments/assets/3f2669ae-8773-4606-b2de-f420b1c3e9e3"> | <img width="1280" alt="Screenshot 2024-10-05 at 4 06 02 AM" src="https://github.com/user-attachments/assets/89c77fb0-f9ad-411b-87cb-f185973274cd"> |

### Checklist:

- [x] Icon size has been adjusted for better visibility.
- [x] Icons are now responsive across different screen sizes.
- [x] Alignment and spacing have been improved.
